### PR TITLE
key requests require url-encoding. Also fix for SearchRequest

### DIFF
--- a/src/main/java/com/wseemann/ecp/request/KeyPressRequest.java
+++ b/src/main/java/com/wseemann/ecp/request/KeyPressRequest.java
@@ -12,13 +12,9 @@ final public class KeyPressRequest extends ECPRequest<Void> {
 
 	private final String key;
 	
-	public KeyPressRequest(String url, String key) {
-		super(url);		
-		try {
-		    key = URLEncoder.encode(key, StandardCharsets.UTF_8.name());
-		} catch (UnsupportedEncodingException e) {
-		}
-		this.key = key;
+	public KeyPressRequest(String url, String key) throws UnsupportedEncodingException {
+		super(url);
+		this.key = URLEncoder.encode(key, StandardCharsets.UTF_8.name());
 	}
 	
 	@Override

--- a/src/main/java/com/wseemann/ecp/request/KeyPressRequest.java
+++ b/src/main/java/com/wseemann/ecp/request/KeyPressRequest.java
@@ -1,5 +1,9 @@
 package com.wseemann.ecp.request;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 import com.wseemann.ecp.core.ECPRequest;
 import com.wseemann.ecp.parser.ECPResponseParser;
 import org.jetbrains.annotations.NotNull;
@@ -10,6 +14,10 @@ final public class KeyPressRequest extends ECPRequest<Void> {
 	
 	public KeyPressRequest(String url, String key) {
 		super(url);		
+		try {
+		    key = URLEncoder.encode(key, StandardCharsets.UTF_8.name());
+		} catch (UnsupportedEncodingException e) {
+		}
 		this.key = key;
 	}
 	

--- a/src/main/java/com/wseemann/ecp/request/KeydownRequest.java
+++ b/src/main/java/com/wseemann/ecp/request/KeydownRequest.java
@@ -1,5 +1,9 @@
 package com.wseemann.ecp.request;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 import com.wseemann.ecp.core.ECPRequest;
 import com.wseemann.ecp.parser.ECPResponseParser;
 import org.jetbrains.annotations.NotNull;
@@ -10,6 +14,10 @@ final public class KeydownRequest extends ECPRequest<Void> {
 	
 	public KeydownRequest(String url, String key) {
 		super(url);		
+		try {
+		    key = URLEncoder.encode(key, StandardCharsets.UTF_8.name());
+		} catch (UnsupportedEncodingException e) {
+		}
 		this.key = key;
 	}
 	

--- a/src/main/java/com/wseemann/ecp/request/KeydownRequest.java
+++ b/src/main/java/com/wseemann/ecp/request/KeydownRequest.java
@@ -12,13 +12,9 @@ final public class KeydownRequest extends ECPRequest<Void> {
 
 	private final String key;
 	
-	public KeydownRequest(String url, String key) {
-		super(url);		
-		try {
-		    key = URLEncoder.encode(key, StandardCharsets.UTF_8.name());
-		} catch (UnsupportedEncodingException e) {
-		}
-		this.key = key;
+	public KeydownRequest(String url, String key) throws UnsupportedEncodingException {
+		super(url);
+		this.key = URLEncoder.encode(key, StandardCharsets.UTF_8.name());
 	}
 	
 	@Override

--- a/src/main/java/com/wseemann/ecp/request/KeyupRequest.java
+++ b/src/main/java/com/wseemann/ecp/request/KeyupRequest.java
@@ -12,13 +12,9 @@ final public class KeyupRequest extends ECPRequest<Void> {
 
 	private final String key;
 	
-	public KeyupRequest(String url, String key) {
-		super(url);		
-		try {
-		    key = URLEncoder.encode(key, StandardCharsets.UTF_8.name());
-		} catch (UnsupportedEncodingException e) {
-		}
-		this.key = key;
+	public KeyupRequest(String url, String key) throws UnsupportedEncodingException {
+		super(url);
+		this.key = URLEncoder.encode(key, StandardCharsets.UTF_8.name());
 	}
 	
 	@Override

--- a/src/main/java/com/wseemann/ecp/request/KeyupRequest.java
+++ b/src/main/java/com/wseemann/ecp/request/KeyupRequest.java
@@ -1,5 +1,9 @@
 package com.wseemann.ecp.request;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 import com.wseemann.ecp.core.ECPRequest;
 import com.wseemann.ecp.parser.ECPResponseParser;
 import org.jetbrains.annotations.NotNull;
@@ -10,6 +14,10 @@ final public class KeyupRequest extends ECPRequest<Void> {
 	
 	public KeyupRequest(String url, String key) {
 		super(url);		
+		try {
+		    key = URLEncoder.encode(key, StandardCharsets.UTF_8.name());
+		} catch (UnsupportedEncodingException e) {
+		}
 		this.key = key;
 	}
 	

--- a/src/main/java/com/wseemann/ecp/request/SearchRequest.java
+++ b/src/main/java/com/wseemann/ecp/request/SearchRequest.java
@@ -1,5 +1,6 @@
 package com.wseemann.ecp.request;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
@@ -84,7 +85,11 @@ final public class SearchRequest extends ECPRequest<Void> {
 	}
 	
 	private String encodeParameter(String parameter) {
-		return URLEncoder.encode(parameter, StandardCharsets.UTF_8);
+		try {
+		    return URLEncoder.encode(parameter, StandardCharsets.UTF_8.name());
+		} catch (UnsupportedEncodingException e) {
+		    return parameter;
+		}
 	}
 
 	@Override


### PR DESCRIPTION
url-encode the key parameter as it is going to be part of the request URL, which is particularly important for the Lit_ case (for example, when trying to send a Space).

All url-encoding calls, including that found in SearchRequest changed to use StandardCharsets.UTF_8.name() or otherwise a MethodNotFound exception was generated at runtime (maybe only on my development Android device, but this is more compatible in general). Also, UnsupportedEncodingException has to be handled, so we just omit the encoding part inside the catch, expecting this exception to never happen as UTF_8 should always be available for URL encoding.